### PR TITLE
Auth 컴포넌트 및 관련 로직들과 Search 페이지 컴포넌트의 useSearch 수정

### DIFF
--- a/src/Hooks/index.js
+++ b/src/Hooks/index.js
@@ -1,0 +1,1 @@
+export * from './useSearch';

--- a/src/Hooks/useSearch.js
+++ b/src/Hooks/useSearch.js
@@ -1,5 +1,6 @@
 import { searchRecipes } from '@api/requestData';
 import { useEffect, useRef, useState } from 'react';
+const RESULTS_PER_PAGE = 12;
 
 export const useSearch = (keyword, currentPage, limit) => {
   const [results, setResults] = useState([]);
@@ -14,7 +15,7 @@ export const useSearch = (keyword, currentPage, limit) => {
       const { results: fetchedResults, totalResults: fetchedTotalResults } = await searchRecipes(
         keyword,
         limit,
-        currentPage * limit,
+        (currentPage-1) * limit,
       );
       storedResults.current[currentPage] = fetchedResults;
       setResults(fetchedResults);

--- a/src/Hooks/useSearch.js
+++ b/src/Hooks/useSearch.js
@@ -2,7 +2,7 @@ import { searchRecipes } from '@api/requestData';
 import { useEffect, useRef, useState } from 'react';
 const RESULTS_PER_PAGE = 12;
 
-export const useSearch = (keyword, currentPage, limit) => {
+export const useSearch = (keyword, currentPage, limit=RESULTS_PER_PAGE) => {
   const [results, setResults] = useState([]);
   const storedResults = useRef({});
   const [isLoading, setIsLoading] = useState(false);

--- a/src/Hooks/useSearch.js
+++ b/src/Hooks/useSearch.js
@@ -1,0 +1,49 @@
+import { searchRecipes } from '@api/requestData';
+import { useEffect, useRef, useState } from 'react';
+
+export const useSearch = (keyword, currentPage, limit) => {
+  const [results, setResults] = useState([]);
+  const storedResults = useRef({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [totalResults, setTotalResults] = useState(0);
+
+  const fetchData = async () => {
+    try {
+      setIsLoading(true);
+      const { results: fetchedResults, totalResults: fetchedTotalResults } = await searchRecipes(
+        keyword,
+        limit,
+        currentPage * limit,
+      );
+      storedResults.current[currentPage] = fetchedResults;
+      setResults(fetchedResults);
+      setTotalResults(fetchedTotalResults);
+    } catch (error) {
+      console.error(error);
+      setError(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    storedResults.current = {};
+  }, [keyword]);
+
+  useEffect(() => {
+    if (!storedResults.current[currentPage]) {
+      fetchData();
+    } else {
+      setResults(storedResults.current[currentPage]);
+    }
+  }, [currentPage]);
+
+  return {
+    results,
+    isLoading,
+    hasError: error !== null,
+    error,
+    totalResults,
+  };
+};

--- a/src/components/Auth/Auth.js
+++ b/src/components/Auth/Auth.js
@@ -1,0 +1,141 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { Dialog } from '..';
+import { useFormik } from 'formik';
+import styles from './Auth.module.scss';
+import imgUrl from '@assets/default.jpg';
+import { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC } from '../../services';
+
+export function Auth({ isVisible, handleCloseDialog }) {
+  const [currentForm, setCurrentForm] = useState('signin');
+
+  const toggleCurrentForm = (e) => {
+    e.preventDefault();
+    setCurrentForm(currentForm === 'signin' ? 'signup' : 'signin');
+  };
+
+  return isVisible ? (
+    <Dialog
+      isVisible={isVisible}
+      onClose={handleCloseDialog}
+      nodeId="dialog"
+      img={imgUrl}
+      label={currentForm}
+      className={styles.memberDialog}
+    >
+      <h2 className={styles.heading}>{HEADING[currentForm]}</h2>
+      {currentForm === 'signin' ? <Auth.SignIn /> : <Auth.SignUp />}
+      <a href="#" role="button" onClick={toggleCurrentForm}>
+        {TOGGLE_MESSAGE[currentForm]}
+      </a>
+    </Dialog>
+  ) : null;
+}
+
+Auth.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  handleCloseDialog: PropTypes.func.isRequired,
+};
+
+Auth.SignIn = function SignIn() {
+  const [hasAuthError, setAuthError] = useState(false);
+  const formik = useFormik({
+    initialValues: INITIAL_VALUES.signin,
+    validationSchema: SCHEMA.signin,
+    onSubmit: async (values) => {
+      try {
+        const user = await AUTH_FUNC.signin(values);
+        setAuthError(false);
+        // 여기에 auth 정보를 context에 update하기
+      } catch (e) {
+        setAuthError(true);
+      }
+    },
+  });
+  return (
+    <>
+      {hasAuthError ? <Auth.Error message={AUTH_ERROR_MSG.signin} /> : null}
+      <form onSubmit={formik.handleSubmit}>
+        <Auth.Field fieldName={'email'} formik={formik} />
+        <Auth.Field fieldName={'password'} formik={formik} />
+        <button type="submit" disabled={!formik.dirty || !formik.isValid}>
+          Submit
+        </button>
+      </form>
+    </>
+  );
+};
+
+Auth.SignUp = function SignUp() {
+  const [hasAuthError, setAuthError] = useState(false);
+  const formik = useFormik({
+    initialValues: INITIAL_VALUES.signup,
+    validationSchema: SCHEMA.signup,
+    onSubmit: async (values) => {
+      try {
+        const user = await AUTH_FUNC.signup(values);
+        setAuthError(false);
+        // 여기에 auth 정보를 context에 update하기
+      } catch (e) {
+        setAuthError(true);
+      }
+    },
+  });
+  return (
+    <>
+      <Auth.Error>{hasAuthError ? AUTH_ERROR_MSG.signup : null}</Auth.Error>
+      <form onSubmit={formik.handleSubmit}>
+        <Auth.Field fieldName={'username'} formik={formik} />
+        <Auth.Field fieldName={'email'} formik={formik} />
+        <Auth.Field fieldName={'password'} formik={formik} />
+        <Auth.Field fieldName={'passwordConfirm'} formik={formik} />
+        <button type="submit" disabled={!formik.dirty || !formik.isValid}>
+          Submit
+        </button>
+      </form>
+    </>
+  );
+};
+
+Auth.Error = function Error({ children }) {
+  return <div className={styles.authError}>{children}</div>;
+};
+
+Auth.Error.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+};
+
+Auth.Field = function Field({ fieldName, formik }) {
+  let type = 'text';
+  switch (fieldName) {
+    case 'password':
+    case 'passwordConfirm':
+      type = 'password';
+      break;
+    case 'email':
+      type = 'email';
+      break;
+    default:
+      type = 'text';
+  }
+  return (
+    <>
+      <label htmlFor={fieldName}>{fieldName.toUpperCase()}</label>
+      <input
+        id={fieldName}
+        name={fieldName}
+        type={type}
+        onChange={formik.handleChange}
+        onBlur={formik.handleBlur}
+        value={formik.values[fieldName] || ''}
+        autoComplete={fieldName === 'password' ? 'current-password' : 'username'}
+      />
+      <div className={styles.fieldError}>{formik.touched[fieldName] && formik.errors[fieldName]}</div>
+    </>
+  );
+};
+
+Auth.Field.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  formik: PropTypes.object.isRequired,
+};

--- a/src/components/Auth/Auth.js
+++ b/src/components/Auth/Auth.js
@@ -4,9 +4,9 @@ import { Dialog } from '..';
 import { useFormik } from 'formik';
 import styles from './Auth.module.scss';
 import imgUrl from '@assets/default.jpg';
-import { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC } from '../../services';
+import { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC, PLACEHOLDER } from '../../services';
 
-export function Auth({ isVisible, handleCloseDialog }) {
+export function Auth({ isVisible, onClose }) {
   const [currentForm, setCurrentForm] = useState('signin');
 
   const toggleCurrentForm = (e) => {
@@ -17,14 +17,14 @@ export function Auth({ isVisible, handleCloseDialog }) {
   return isVisible ? (
     <Dialog
       isVisible={isVisible}
-      onClose={handleCloseDialog}
+      onClose={onClose}
       nodeId="dialog"
       img={imgUrl}
       label={currentForm}
       className={styles.memberDialog}
     >
       <h2 className={styles.heading}>{HEADING[currentForm]}</h2>
-      {currentForm === 'signin' ? <Auth.SignIn /> : <Auth.SignUp />}
+      {currentForm === 'signin' ? <Auth.SignIn onClose={onClose} /> : <Auth.SignUp onClose={onClose} />}
       <a href="#" role="button" onClick={toggleCurrentForm}>
         {TOGGLE_MESSAGE[currentForm]}
       </a>
@@ -37,7 +37,7 @@ Auth.propTypes = {
   handleCloseDialog: PropTypes.func.isRequired,
 };
 
-Auth.SignIn = function SignIn() {
+Auth.SignIn = function SignIn({ onClose }) {
   const [hasAuthError, setAuthError] = useState(false);
   const formik = useFormik({
     initialValues: INITIAL_VALUES.signin,
@@ -46,6 +46,7 @@ Auth.SignIn = function SignIn() {
       try {
         const user = await AUTH_FUNC.signin(values);
         setAuthError(false);
+        onClose();
         // 여기에 auth 정보를 context에 update하기
       } catch (e) {
         setAuthError(true);
@@ -54,8 +55,8 @@ Auth.SignIn = function SignIn() {
   });
   return (
     <>
-      {hasAuthError ? <Auth.Error message={AUTH_ERROR_MSG.signin} /> : null}
-      <form onSubmit={formik.handleSubmit}>
+      <Auth.Error>{hasAuthError ? AUTH_ERROR_MSG.signin : null} </Auth.Error>
+      <form className={styles.form} onSubmit={formik.handleSubmit}>
         <Auth.Field fieldName={'email'} formik={formik} />
         <Auth.Field fieldName={'password'} formik={formik} />
         <button type="submit" disabled={!formik.dirty || !formik.isValid}>
@@ -66,7 +67,11 @@ Auth.SignIn = function SignIn() {
   );
 };
 
-Auth.SignUp = function SignUp() {
+Auth.SignIn.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+
+Auth.SignUp = function SignUp({ onClose }) {
   const [hasAuthError, setAuthError] = useState(false);
   const formik = useFormik({
     initialValues: INITIAL_VALUES.signup,
@@ -75,6 +80,7 @@ Auth.SignUp = function SignUp() {
       try {
         const user = await AUTH_FUNC.signup(values);
         setAuthError(false);
+        onClose();
         // 여기에 auth 정보를 context에 update하기
       } catch (e) {
         setAuthError(true);
@@ -84,7 +90,7 @@ Auth.SignUp = function SignUp() {
   return (
     <>
       <Auth.Error>{hasAuthError ? AUTH_ERROR_MSG.signup : null}</Auth.Error>
-      <form onSubmit={formik.handleSubmit}>
+      <form className={styles.form} onSubmit={formik.handleSubmit}>
         <Auth.Field fieldName={'username'} formik={formik} />
         <Auth.Field fieldName={'email'} formik={formik} />
         <Auth.Field fieldName={'password'} formik={formik} />
@@ -97,8 +103,11 @@ Auth.SignUp = function SignUp() {
   );
 };
 
-Auth.Error = function Error({ children }) {
-  return <div className={styles.authError}>{children}</div>;
+Auth.SignUp.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+Auth.Error = function Error({ ...restProps }) {
+  return <div className={styles.authError} {...restProps} />;
 };
 
 Auth.Error.propTypes = {
@@ -120,10 +129,11 @@ Auth.Field = function Field({ fieldName, formik }) {
   }
   return (
     <>
-      <label htmlFor={fieldName}>{fieldName.toUpperCase()}</label>
+      <label className='a11y-hidden' htmlFor={fieldName}>{fieldName.toUpperCase()}</label>
       <input
         id={fieldName}
         name={fieldName}
+        placeholder={PLACEHOLDER[fieldName]}
         type={type}
         onChange={formik.handleChange}
         onBlur={formik.handleBlur}

--- a/src/components/Auth/Auth.module.scss
+++ b/src/components/Auth/Auth.module.scss
@@ -1,0 +1,38 @@
+@use '@styles/' as *;
+
+.memberDialog {
+  @include flexbox(column, center, center);
+  gap: rem(20px);
+}
+.heading {
+  font-size: rem(30px);
+}
+
+.authError {
+  height: rem(16px);
+  background-color: blue;
+}
+
+.form {
+  @include flexbox(column);
+  width: 50vw;
+  max-width: rem(500px);
+  min-width: rem(250px);
+  gap: rem(6px);
+  input, button {
+    padding: 0 rem(24px);
+    height: rem(36px);
+    border: none;
+    border-radius: rem(18px) rem(18px);
+  }
+  button {
+    line-height: rem(36px);
+    &[disabled] {
+      cursor: not-allowed;
+    }
+  }
+  
+  .fieldError {
+    height: rem(16px);
+  }
+}

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -3,8 +3,9 @@ import { string, bool, func, node, oneOf, oneOfType, any } from 'prop-types';
 import { createPortal } from 'react-dom';
 import { getTabbableElements } from '../../utils';
 import styles from './Dialog.module.scss';
+import classNames from 'classnames';
 
-export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', img, ...restProps }) {
+export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', label, img, className,...restProps }) {
   const scrollY = useRef(window.scrollY);
   const dialogRef = useRef(null);
   const openButtonRef = useRef(null);
@@ -27,7 +28,6 @@ export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', img, .
 
     // 첫번째 탭 이동 가능한 요소에 포커싱
     firstTabbableElement.focus();
-
     // 이벤트 타입
     let eventType = 'keydown';
 
@@ -67,21 +67,21 @@ export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', img, .
       document.body.style.top = '';
       window.scrollTo(0, parseInt(scrollY.current || '0') * -1);
     };
-  }, [handleClose]);
+  }, [handleClose, label]);
 
   return createPortal(
     <>
       <div
         ref={dialogRef}
-        className={styles.container}
+        className={classNames(styles.container, className)}
         role="dialog"
         aria-modal="true"
         aria-hidden={!isVisible}
-        aria-label="React Portal﹕모달 다이얼로그"
+        aria-label={`${label} Dialog`}
         {...restProps}
       >
         <div className={styles.content}>{children}</div>
-        <Dialog.CloseButton onClose={handleClose} />
+        <Dialog.CloseButton onClose={handleClose} label={label}/>
       </div>
       {img ? <Dialog.Image img={img} /> : null}
     </>,
@@ -90,11 +90,12 @@ export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', img, .
 }
 
 Dialog.propTypes = {
-  isVisible: bool,
+  isVisible: bool.isRequired,
   onClose: func.isRequired,
   children: node.isRequired,
   nodeId: string,
   img: string,
+  label: string.isRequired,
   restProps: any,
 };
 
@@ -110,13 +111,13 @@ Dialog.Dim.propTypes = {
 
 /* -------------------------------------------------------------------------- */
 
-Dialog.CloseButton = function DialogCloseButton({ onClose }) {
+Dialog.CloseButton = function DialogCloseButton({ onClose, label }) {
   return (
     <button
       type="button"
       className={styles.closeButton}
-      aria-label="모달 다이얼로그 닫기"
-      title="모달 다이얼로그 닫기"
+      aria-label={`Close ${label} dialog.`}
+      title={`Close ${label} dialog.`}
       onClick={onClose}
     >
       <svg width="24" height="24" fillRule="evenodd" clipRule="evenodd">
@@ -127,7 +128,8 @@ Dialog.CloseButton = function DialogCloseButton({ onClose }) {
 };
 
 Dialog.CloseButton.propTypes = {
-  onClose: func,
+  onClose: func.isRequired,
+  label: string.isRequired
 };
 
 /* -------------------------------------------------------------------------- */

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -5,7 +5,7 @@ import { getTabbableElements } from '../../utils';
 import styles from './Dialog.module.scss';
 import classNames from 'classnames';
 
-export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', label, img, className,...restProps }) {
+export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', label, img, className, ...restProps }) {
   const scrollY = useRef(window.scrollY);
   const dialogRef = useRef(null);
   const openButtonRef = useRef(null);
@@ -55,7 +55,7 @@ export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', label,
 
     document.body.style.position = 'fixed';
     document.body.style.top = `-${scrollY.current}px`;
-    
+
     // 이펙트 클린업(정리) 함수
     return () => {
       // 이벤트 구독 취소
@@ -73,15 +73,15 @@ export function Dialog({ isVisible, onClose, children, nodeId = 'dialog', label,
     <>
       <div
         ref={dialogRef}
-        className={classNames(styles.container, className)}
+        className={styles.container}
         role="dialog"
         aria-modal="true"
         aria-hidden={!isVisible}
         aria-label={`${label} Dialog`}
         {...restProps}
       >
-        <div className={styles.content}>{children}</div>
-        <Dialog.CloseButton onClose={handleClose} label={label}/>
+        <div className={classNames(className, styles.content)}>{children}</div>
+        <Dialog.CloseButton onClose={handleClose} label={label} />
       </div>
       {img ? <Dialog.Image img={img} /> : null}
     </>,
@@ -129,7 +129,7 @@ Dialog.CloseButton = function DialogCloseButton({ onClose, label }) {
 
 Dialog.CloseButton.propTypes = {
   onClose: func.isRequired,
-  label: string.isRequired
+  label: string.isRequired,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/src/components/Dialog/Dialog.module.scss
+++ b/src/components/Dialog/Dialog.module.scss
@@ -19,6 +19,7 @@
 }
 
 .content {
+  z-index: 200;
   padding: 4rem;
   color: #121212;
   height: 100%;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,15 +1,36 @@
 import styles from './Header.module.scss';
 import { SearchForm } from '../../components';
 import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Auth } from '../Auth/Auth';
 
 export function Header() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleOpenDialog = () => {
+    setIsVisible(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsVisible(false);
+  };
+
   return (
     <header className={styles.header}>
       <div className={styles.wrapper}>
         <Link to="/">Han Spoon</Link>
         <SearchForm />
       </div>
-      <div>로그인버튼</div>
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-label="Open SignIn Dialog"
+        title="Open SignIn Dialog"
+        onClick={handleOpenDialog}
+      >
+        로그인버튼
+      </button>
+      <Auth isVisible={isVisible} onClose={handleCloseDialog} />
     </header>
   );
 }

--- a/src/pages/Search/Search.js
+++ b/src/pages/Search/Search.js
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { searchRecipes } from '@api/requestData';
 import { Card } from '../../components';
+import { useSearch } from '../../Hooks';
 import classNames from 'classnames';
 import styles from './Search.module.scss';
 
@@ -9,7 +9,7 @@ const RESULTS_PER_PAGE = 12;
 export default function Search() {
   const { keyword } = useParams();
   const [currentPage, setCurrentPage] = useState(1);
-  const { totalResults, results, isLoading, hasError, error } = useSearch(keyword, currentPage);
+  const { totalResults, results, isLoading, hasError, error } = useSearch(keyword, currentPage, RESULTS_PER_PAGE);
 
   const handleClick = (num) => {
     setCurrentPage(num);
@@ -18,7 +18,7 @@ export default function Search() {
   useEffect(() => {
     setCurrentPage(1);
   }, [keyword]);
-  
+
   return (
     <div className={classNames(styles.container)}>
       <ul className={styles.searchResultsList}>
@@ -106,51 +106,4 @@ Search.PageControl = ({ currentPage, className, onClick: handleClick, totalResul
       </button>
     </div>
   );
-};
-
-const useSearch = (keyword, currentPage) => {
-  const [results, setResults] = useState([]);
-  const storedResults = useRef({});
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [totalResults, setTotalResults] = useState(0);
-
-  const fetchData = async () => {
-    try {
-      setIsLoading(true);
-      const { results: fetchedResults, totalResults: fetchedTotalResults } = await searchRecipes(
-        keyword,
-        RESULTS_PER_PAGE,
-        currentPage * RESULTS_PER_PAGE,
-      );
-      storedResults.current[currentPage] = fetchedResults;
-      setResults(fetchedResults);
-      setTotalResults(fetchedTotalResults);
-    } catch (error) {
-      console.error(error);
-      setError(error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    storedResults.current = {};
-  }, [keyword]);
-
-  useEffect(() => {
-    if (!storedResults.current[currentPage]) {
-      fetchData();
-    } else {
-      setResults(storedResults.current[currentPage]);
-    }
-  }, [currentPage]);
-
-  return {
-    results,
-    isLoading,
-    hasError: error !== null,
-    error,
-    totalResults,
-  };
 };

--- a/src/pages/Search/Search.js
+++ b/src/pages/Search/Search.js
@@ -2,14 +2,15 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card } from '../../components';
 import { useSearch } from '../../Hooks';
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
+import { IoEllipsisHorizontalSharp } from 'react-icons/io5';
 import classNames from 'classnames';
 import styles from './Search.module.scss';
 
-const RESULTS_PER_PAGE = 12;
 export default function Search() {
   const { keyword } = useParams();
   const [currentPage, setCurrentPage] = useState(1);
-  const { totalResults, results, isLoading, hasError, error } = useSearch(keyword, currentPage, RESULTS_PER_PAGE);
+  const { totalResults, results, isLoading, hasError, error } = useSearch(keyword, currentPage);
 
   const handleClick = (num) => {
     setCurrentPage(num);
@@ -47,10 +48,25 @@ export default function Search() {
 
 Search.PageList = ({ className, currentPage, limit, totalResults, onClick: handleClick }) => {
   const lastPageNum = Math.ceil(totalResults / limit);
-  const pageStartNum = Math.floor((currentPage - 1) / limit) * limit + 1;
-  const pageEndNum = pageStartNum + limit - 1 < lastPageNum ? pageStartNum + limit - 1 : lastPageNum;
+  const pageStartNum = Math.max(currentPage - 2, 1);
+  const pageEndNum = Math.min(currentPage + 2, lastPageNum);
   return (
-    <ul className={className}>
+    <ul className={classNames(className, styles.pageNumberList)}>
+      {currentPage > 3 ? (
+        <li>
+          <button
+            type="button"
+            className={styles.pageButton}
+            aria-pressed={false}
+            aria-label={`Go to previous pages.`}
+            onClick={() => {
+              handleClick(currentPage - 3);
+            }}
+          >
+            <IoEllipsisHorizontalSharp />
+          </button>
+        </li>
+      ) : null}
       {Array.from({ length: pageEndNum - pageStartNum + 1 }, (_, i) => {
         return (
           <li key={i} className={classNames({ [styles.current]: currentPage === pageStartNum + i })}>
@@ -68,6 +84,21 @@ Search.PageList = ({ className, currentPage, limit, totalResults, onClick: handl
           </li>
         );
       })}
+      {currentPage < lastPageNum - 2 ? (
+        <li>
+          <button
+            type="button"
+            className={styles.pageButton}
+            aria-pressed={false}
+            aria-label={`Go to next pages.`}
+            onClick={() => {
+              handleClick(currentPage + 3);
+            }}
+          >
+            <IoEllipsisHorizontalSharp />{' '}
+          </button>
+        </li>
+      ) : null}
     </ul>
   );
 };
@@ -84,13 +115,13 @@ Search.PageControl = ({ currentPage, className, onClick: handleClick, totalResul
           handleClick(currentPage - 1);
         }}
       >
-        PREV
+        <IoIosArrowBack />
       </button>
       <Search.PageList
         className={styles.pageList}
         currentPage={currentPage}
         totalResults={totalResults}
-        limit={RESULTS_PER_PAGE}
+        limit={5}
         onClick={handleClick}
       />
       <button
@@ -98,11 +129,11 @@ Search.PageControl = ({ currentPage, className, onClick: handleClick, totalResul
         className={styles.pageButton}
         aria-label={`Go to next results page.`}
         onClick={() => {
-          if (currentPage > Math.floor(totalResults / RESULTS_PER_PAGE)) return;
+          if (currentPage > Math.floor(totalResults / 5)) return;
           handleClick(currentPage + 1);
         }}
       >
-        NEXT
+        <IoIosArrowForward />
       </button>
     </div>
   );

--- a/src/pages/Search/Search.module.scss
+++ b/src/pages/Search/Search.module.scss
@@ -9,24 +9,38 @@
 }
 
 .control {
-  @include flexbox(row, center);
-  gap: rem(20px);
-  .pageButton {
+  @include flexbox(row, center, center);
+  gap: rem(20px) 4;
+  button {
     border: none;
     background: transparent;
-    font-weight: 500;
-    &:hover {
-      opacity: 0.5;
+    color: $primary-orange;
+  }
+  .pageNumberList {
+    @include flexbox(row, center, center);
+   
+    .pageButton {
+      border: 1px solid $primary-orange;
+      border-radius: rem(5px);
+      background: $white;
+      width: rem(32px);
+      height: rem(32px);
+      margin: rem(6px);
+      @include flexbox(row, center, center);
+      &:hover {
+        opacity: 0.5;
+      }
     }
   }
 }
 
 .pageList {
   @include flexbox();
-  
-  
 
   .current {
-    color: $primary-orange;
+    .pageButton {
+      color: $white;
+      background-color: $primary-orange;
+    }
   }
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,4 +1,59 @@
 import * as Yup from 'yup';
+import { signIn, signUp } from '../api/requestAuth';
+
+
+const TOGGLE_MESSAGE = {
+  signin: 'Not registered yet? Sign up here!',
+  signup: 'Already a member? Sign in here!',
+};
+
+const HEADING = {
+  signin: 'Sign In',
+  signup: 'Sign Up',
+};
+
+const INITIAL_VALUES = {
+  signin: {
+    password: '',
+    email: '',
+  },
+  signup: {
+    username: '',
+    password: '',
+    passwordConfirm: '',
+    email: '',
+  },
+};
+
+const SCHEMA = {
+  signin: Yup.object({
+    password: Yup.string().min(8, 'Must be 8 characters or more').required('Required'),
+    email: Yup.string().email('Invalid email address').required('Required'),
+  }),
+  signup: Yup.object({
+    username: Yup.string().min(3, 'Must be 3 characters or more').required('Required'),
+    password: Yup.string().min(8, 'Must be 8 characters or more').required('Required'),
+    passwordConfirm: Yup.string()
+      .oneOf([Yup.ref('password'), null], 'Passwords must match')
+      .required('Required'),
+    email: Yup.string().email('Invalid email address').required('Required'),
+  })
+}
+
+const AUTH_ERROR_MSG = {
+  signin: 'Login failed. Please try again.',
+  signup: 'Signup failed. Please try again.',
+};
+
+const FIELDS = {
+  signin: ['email', 'password'],
+  signup: ['username', 'email', 'password', 'passwordConfirm']
+}
+
+const AUTH_FUNC = {
+  signin: signIn,
+  signup: signUp
+}
 
 export const signInSchema = Yup.object({
   password: Yup.string().min(8, 'Must be 8 characters or more').required('Required'),
@@ -41,13 +96,10 @@ export function FormikField({ fieldname, formik }) {
       {formik.touched[fieldname] && formik.errors[fieldname] ? <div>{formik.errors[fieldname]}</div> : null}
     </>
   );
-};
-
-const AUTH_ERROR_MSG = {
-  login: 'Login failed. Please try again.',
-  signup: 'Signup failed. Please try again.'
 }
 
-export function AuthError ({type}) {
-  return <div className="auth-error">{AUTH_ERROR_MSG[type]}</div>
+export function AuthError({ type }) {
+  return <div className="auth-error">{AUTH_ERROR_MSG[type]}</div>;
 }
+
+export { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC, FIELDS };

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -60,6 +60,13 @@ export const signInSchema = Yup.object({
   email: Yup.string().email('Invalid email address').required('Required'),
 });
 
+const PLACEHOLDER = {
+  username: 'Username',
+  email: 'Email',
+  password: 'Password',
+  passwordConfirm: 'Confirm password'
+}
+
 export const signUpSchema = Yup.object({
   username: Yup.string().min(3, 'Must be 3 characters or more').required('Required'),
   password: Yup.string().min(8, 'Must be 8 characters or more').required('Required'),
@@ -102,4 +109,5 @@ export function AuthError({ type }) {
   return <div className="auth-error">{AUTH_ERROR_MSG[type]}</div>;
 }
 
-export { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC, FIELDS };
+export { TOGGLE_MESSAGE, HEADING, INITIAL_VALUES, SCHEMA, AUTH_ERROR_MSG, AUTH_FUNC, FIELDS, PLACEHOLDER };
+


### PR DESCRIPTION
## Related Issue
#9 #30 

## Done
- 비동기 호출을 useSearch 훅으로 뺐습니다.
- signin과 signup을 auth 컴포넌트의 컴파운드컴포넌트로 만들었습니다.
- services/auth에서 필요한 로직을 정리했습니다.
 
## 비고
별도로 만든 SignIn과 SignUp 컴포넌트 삭제 예정
