### PR TITLE
Card 컴포넌트에 Dialog 로직 추가

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -46,7 +46,7 @@ export function Card({
           label={title}
           className={styles.detailDialog}
         >
-          <Detail id={id} />
+          <Detail id={id} imgSrc={imgSrc} title={title} />
         </Dialog>
       ) : null}
     </>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import styles from './Card.module.scss';
 import classNames from 'classnames';
 import { excludeTags } from '@utils/misc';
-
+import { useState } from 'react';
+import { Dialog } from '..';
 export function Card({
   id = 0,
   type,
@@ -15,22 +16,42 @@ export function Card({
   title,
   summary = '',
 }) {
-  function handleClick(e) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleOpenDialog = (e) => {
     e.preventDefault();
-    console.log(id);
-  }
+    setIsVisible(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsVisible(false);
+  };
   return (
-    <a role="button" onClick={handleClick}>
-      <div className={classNames({ [styles.inlineBlock]: type === 'square' })}>
-        <figure
-          className={classNames(styles['cardWrap'], styles[background], { [styles.inlineBlock]: type === 'square' })}
+    <>
+      <a href="#" role="button" onClick={handleOpenDialog}>
+        <div className={classNames({ [styles.inlineBlock]: type === 'square' })}>
+          <figure
+            className={classNames(styles['cardWrap'], styles[background], { [styles.inlineBlock]: type === 'square' })}
+          >
+            <img className={styles[type]} src={imgSrc} alt={title + 'picture'} />
+            <figcaption className={classNames(styles['title'], styles[headingPosition])}>{title}</figcaption>
+            <span className={styles[hasSummary]}>{excludeTags(summary)}</span>
+          </figure>
+        </div>
+      </a>
+      {isVisible ? (
+        <Dialog
+          isVisible={isVisible}
+          onClose={handleCloseDialog}
+          nodeId="dialog"
+          img={imgSrc}
+          label={title}
+          className={styles.memberDialog}
         >
-          <img className={styles[type]} src={imgSrc} alt={title + 'picture'} />
-          <figcaption className={classNames(styles['title'], styles[headingPosition])}>{title}</figcaption>
-          <span className={styles[hasSummary]}>{excludeTags(summary)}</span>
-        </figure>
-      </div>
-    </a>
+          <h2 className={styles.heading}>이곳이 바로 상세페이지입니다</h2>
+        </Dialog>
+      ) : null}
+    </>
   );
 }
 

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -3,7 +3,7 @@ import styles from './Card.module.scss';
 import classNames from 'classnames';
 import { excludeTags } from '@utils/misc';
 import { useState } from 'react';
-import { Dialog } from '..';
+import { Dialog, Detail } from '..';
 export function Card({
   id = 0,
   type,
@@ -46,7 +46,7 @@ export function Card({
           label={title}
           className={styles.detailDialog}
         >
-          <h2 className={styles.heading}>{id+'번 레시피에 대한 상세 내용이 여기 들어갑니다.'}</h2>
+          <Detail id={id} />
         </Dialog>
       ) : null}
     </>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -10,8 +10,6 @@ export function Card({
   background,
   hasSummary,
   headingPosition,
-  headingSize,
-  padding,
   imgSrc = 'http://placehold.it/312x230',
   title,
   summary = '',
@@ -31,10 +29,10 @@ export function Card({
       <a href="#" role="button" onClick={handleOpenDialog}>
         <div className={classNames({ [styles.inlineBlock]: type === 'square' })}>
           <figure
-            className={classNames(styles['cardWrap'], styles[background], { [styles.inlineBlock]: type === 'square' })}
+            className={classNames(styles.cardWrap, styles[background], { [styles.inlineBlock]: type === 'square' })}
           >
-            <img className={styles[type]} src={imgSrc} alt={title + 'picture'} />
-            <figcaption className={classNames(styles['title'], styles[headingPosition])}>{title}</figcaption>
+            <img className={styles[type]} src={imgSrc} alt={title} />
+            <figcaption className={classNames(styles.title, styles[headingPosition])}>{title}</figcaption>
             <span className={styles[hasSummary]}>{excludeTags(summary)}</span>
           </figure>
         </div>
@@ -46,9 +44,9 @@ export function Card({
           nodeId="dialog"
           img={imgSrc}
           label={title}
-          className={styles.memberDialog}
+          className={styles.detailDialog}
         >
-          <h2 className={styles.heading}>이곳이 바로 상세페이지입니다</h2>
+          <h2 className={styles.heading}>{id+'번 레시피에 대한 상세 내용이 여기 들어갑니다.'}</h2>
         </Dialog>
       ) : null}
     </>

--- a/src/pages/Search/Search.js
+++ b/src/pages/Search/Search.js
@@ -26,6 +26,7 @@ export default function Search() {
         {results.map(({ id, image, title }) => (
           <li key={id}>
             <Card
+              id={id}
               type="square"
               background="white"
               hasSummary={false}


### PR DESCRIPTION
## Related Issue
#30 #14 #21

## Done
- Card.js에 Dialog 띄우는 로직을 추가했습니다.


## 비고
- 이제 Card.js의 Dialog 요소 내부에 있는 h2를 걷어내고 Detail 페이지를 끼워넣어주시면 됩니다 @skojphy 
