### PR TITLE
Fix markup structure of accordion summary

### DIFF
--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -3,8 +3,8 @@ import Collapse from './Collapse';
 import styles from './Accordion.module.scss';
 
 const Accordion = ({ recipeDetails }) => {
-  const recipiInfoItems = recipeDetails.map((recipeInfo, index) => (
-    <Collapse key={'collapse' + index} heading={recipeInfo.type} content={recipeInfo.data} />
+  const recipiInfoItems = recipeDetails.map((recipeInfo) => (
+    <Collapse key={recipeInfo.type} heading={recipeInfo.type} content={recipeInfo.data} />
   ));
 
   return <ul className={styles.Accordion}>{recipiInfoItems}</ul>;

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -4,7 +4,7 @@ import styles from './Accordion.module.scss';
 
 const Accordion = ({ recipeDetails }) => {
   const recipiInfoItems = recipeDetails.map((recipeInfo, index) => (
-    <Collapse key={index} heading={recipeInfo.type} content={recipeInfo.data} />
+    <Collapse key={'collapse' + index} heading={recipeInfo.type} content={recipeInfo.data} />
   ));
 
   return <ul className={styles.Accordion}>{recipiInfoItems}</ul>;

--- a/src/components/Accordion/Accordion.module.scss
+++ b/src/components/Accordion/Accordion.module.scss
@@ -19,6 +19,7 @@
 summary {
   list-style: none;
   cursor: pointer;
+  padding: rem(3px);
 }
 
 .collapseHeading {

--- a/src/components/Accordion/Collapse.js
+++ b/src/components/Accordion/Collapse.js
@@ -25,9 +25,9 @@ const Collapse = ({ heading, content }) => {
       break;
     case 'summary':
       collapseContent = (
-        <p className={styles.collapseContent}>
+        <div className={styles.collapseContent}>
           <CollapseContent type={heading} content={content} />
-        </p>
+        </div>
       );
       break;
     case 'instructions':

--- a/src/components/Accordion/Collapse.js
+++ b/src/components/Accordion/Collapse.js
@@ -4,40 +4,30 @@ import CollapseContent from './CollapseContent';
 import styles from './Accordion.module.scss';
 
 const Collapse = ({ heading, content }) => {
-  let collapseContent = null;
+  let collapseContentContainer = null;
+  const collapseContentComponent = <CollapseContent type={heading} content={content} />;
+
   switch (heading) {
     case 'ingredients':
-      collapseContent = (
-        <ul className={styles.collapseContent}>
-          <CollapseContent type={heading} content={content} />
-        </ul>
-      );
+      collapseContentContainer = <ul className={styles.collapseContent}>{collapseContentComponent}</ul>;
       break;
     case 'equipment':
-      collapseContent =
+      collapseContentContainer =
         !content || !content.length ? (
           <p>No Equipment.</p>
         ) : (
-          <ul className={styles.collapseContent}>
-            <CollapseContent type={heading} content={content} />
-          </ul>
+          <ul className={styles.collapseContent}>{collapseContentComponent}</ul>
         );
       break;
     case 'summary':
-      collapseContent = (
-        <div className={styles.collapseContent}>
-          <CollapseContent type={heading} content={content} />
-        </div>
-      );
+      collapseContentContainer = <div className={styles.collapseContent}>{collapseContentComponent}</div>;
       break;
     case 'instructions':
-      collapseContent =
+      collapseContentContainer =
         !content || !content.length ? (
           <p>No Instructions.</p>
         ) : (
-          <ol className={styles.collapseContent} type="1">
-            <CollapseContent type={heading} content={content} />
-          </ol>
+          <ol className={styles.collapseContent}>{collapseContentComponent}</ol>
         );
       break;
     default:
@@ -50,7 +40,7 @@ const Collapse = ({ heading, content }) => {
         <summary>
           <CollapseHeading heading={heading} />
         </summary>
-        {collapseContent}
+        {collapseContentContainer}
       </details>
     </li>
   );

--- a/src/components/Accordion/CollapseContent.js
+++ b/src/components/Accordion/CollapseContent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './Accordion.module.scss';
+import { sentenceIntoParagraph } from '@utils';
 
 const CollapseContent = ({ type, content }) => {
   switch (type) {
@@ -13,11 +14,7 @@ const CollapseContent = ({ type, content }) => {
     case 'equipment':
       return content.map((equipment, index) => <li key={'equipment' + index}>{equipment}</li>);
     case 'summary':
-      return content.split('. ').map((text, index, texts) => (
-        <p key={'summary' + index} className={styles.accordionText}>
-          {text + (index < texts.length - 1 ? '.' : '')}
-        </p>
-      ));
+      return sentenceIntoParagraph(content, 'summary', styles.accordionText);
     case 'instructions':
       return content.map((instructions, index) => (
         <li key={'instructions' + index}>

--- a/src/components/Accordion/CollapseContent.js
+++ b/src/components/Accordion/CollapseContent.js
@@ -6,19 +6,19 @@ const CollapseContent = ({ type, content }) => {
   switch (type) {
     case 'ingredients':
       return content.map((ingredient, index) => (
-        <li key={'ingredient' + index} className={styles.ingredient}>
+        <li key={ingredient.name + index} className={styles.ingredient}>
           <span>{ingredient.name}</span>
           <span>{`${ingredient.amount.toFixed(2)} ${ingredient.unit}`}</span>
         </li>
       ));
     case 'equipment':
-      return content.map((equipment, index) => <li key={'equipment' + index}>{equipment}</li>);
+      return content.map((equipment, index) => <li key={equipment + index}>{equipment}</li>);
     case 'summary':
-      return sentenceIntoParagraph(content, 'summary', styles.accordionText);
+      return sentenceIntoParagraph(content, styles.accordionText);
     case 'instructions':
-      return content.map((instructions, index) => (
-        <li key={'instructions' + index}>
-          <p className={styles.accordionText}>{instructions}</p>
+      return content.map((instruction, index) => (
+        <li key={instruction + index}>
+          <p className={styles.accordionText}>{instruction}</p>
         </li>
       ));
     default:

--- a/src/components/Accordion/CollapseContent.js
+++ b/src/components/Accordion/CollapseContent.js
@@ -5,26 +5,22 @@ const CollapseContent = ({ type, content }) => {
   switch (type) {
     case 'ingredients':
       return content.map((ingredient, index) => (
-        <li key={index} className={styles.ingredient}>
+        <li key={'ingredient' + index} className={styles.ingredient}>
           <span>{ingredient.name}</span>
           <span>{`${ingredient.amount.toFixed(2)} ${ingredient.unit}`}</span>
         </li>
       ));
     case 'equipment':
-      return content.map((equipment, index) => <li key={index}>{equipment}</li>);
+      return content.map((equipment, index) => <li key={'equipment' + index}>{equipment}</li>);
     case 'summary':
-      return (
-        <span>
-          {content
-            .split('. ')
-            .map((text, index, texts) =>
-              index < texts.length - 1 ? <p className={styles.accordionText}>{text + '.'}</p> : <p>{text}</p>,
-            )}
-        </span>
-      );
+      return content.split('. ').map((text, index, texts) => (
+        <p key={'summary' + index} className={styles.accordionText}>
+          {text + (index < texts.length - 1 ? '.' : '')}
+        </p>
+      ));
     case 'instructions':
       return content.map((instructions, index) => (
-        <li key={index}>
+        <li key={'instructions' + index}>
           <p className={styles.accordionText}>{instructions}</p>
         </li>
       ));

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -76,11 +76,9 @@ export function Card({
           },
         ];
         savedRecipe.saved = 0;
-        saveRecipe.tags = [
-          ...savedRecipe.diets,
-          savedRecipe.veryHealthy ? 'veryHealthy' : null,
-          savedRecipe.veryPopular ? 'veryPopular' : null,
-        ];
+        savedRecipe.tags = [...savedRecipe.diets.filter((diet) => [diet !== 'fodmap friendly'])];
+        if (savedRecipe.veryPopular) savedRecipe.tags = [...savedRecipe.tags, 'popular'];
+        if (savedRecipe.veryHealthy) savedRecipe.tags = [...savedRecipe.tags, 'healthy'];
       }
       setRecipeData(savedRecipe);
       setSavedCount(savedRecipe.saved);

--- a/src/components/Detail/Detail.js
+++ b/src/components/Detail/Detail.js
@@ -40,7 +40,7 @@ export function Detail({ title, imgSrc, recipeData, savedCount, isSaved, handleC
         {tags && tags.length ? (
           <ul className={styles.badgeList}>
             {tags.map((tag, index) => (
-              <li key={'badgeTag' + index}>
+              <li key={tag + index}>
                 <Badge state={camelCase(tag)} size="small" />
               </li>
             ))}

--- a/src/components/Detail/Detail.js
+++ b/src/components/Detail/Detail.js
@@ -3,8 +3,8 @@ import { Heading, IconButton, Label, Badge } from '../';
 import Accordion from '../Accordion/Accordion';
 import styles from './Detail.module.scss';
 
-export function Detail({ id, title, imgSrc, recipeData, savedCount, isSaved, handleClick }) {
-  const { creditsText, diets, readyInMinutes, recipeDetails, isHealthy, isPopular } = recipeData;
+export function Detail({ title, imgSrc, recipeData, savedCount, isSaved, handleClick }) {
+  const { creditsText, readyInMinutes, recipeDetails, tags } = recipeData;
 
   return (
     <article className={styles.detail}>
@@ -37,21 +37,11 @@ export function Detail({ id, title, imgSrc, recipeData, savedCount, isSaved, han
           <img className={styles.foodImage} src={imgSrc} alt={title} />
           <figcaption className={styles.creditsText}>{creditsText}</figcaption>
         </figure>
-        {diets && diets.length ? (
+        {tags && tags.length ? (
           <ul className={styles.badgeList}>
-            {isHealthy ? (
-              <li key={0}>
-                <Badge state={'healthy'} size="small" />
-              </li>
-            ) : null}
-            {isPopular ? (
-              <li key={0}>
-                <Badge state={'popular'} size="small" />
-              </li>
-            ) : null}
-            {diets.map((diet, index) => (
-              <li key={index + 2}>
-                <Badge state={camelCase(diet)} size="small" />
+            {tags.map((tag, index) => (
+              <li key={'badgeTag' + index}>
+                <Badge state={camelCase(tag)} size="small" />
               </li>
             ))}
           </ul>

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -2,9 +2,9 @@ export const excludeTags = (content) => content.replace(/<[^>]*>/g, '');
 
 export const camelCase = (data) => data.toString().replace(/\s\w/g, (match) => match.toUpperCase().trim());
 
-export const sentenceIntoParagraph = (content, key, className) =>
+export const sentenceIntoParagraph = (content, className) =>
   content.split('. ').map((text, index, texts) => (
-    <p key={key + index} className={className}>
+    <p key={text + index} className={className}>
       {text + (index < texts.length - 1 ? '.' : '')}
     </p>
   ));

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,3 +1,10 @@
 export const excludeTags = (content) => content.replace(/<[^>]*>/g, '');
 
 export const camelCase = (data) => data.toString().replace(/\s\w/g, (match) => match.toUpperCase().trim());
+
+export const sentenceIntoParagraph = (content, key, className) =>
+  content.split('. ').map((text, index, texts) => (
+    <p key={key + index} className={className}>
+      {text + (index < texts.length - 1 ? '.' : '')}
+    </p>
+  ));


### PR DESCRIPTION
## Related Issue
#135

## Done
- 아코디언 summary의 p 태그 중첩 마크업 문제 해결
- list 렌더링의 key props 수정
- 문단을 문장 단위로 끊어 p 태그로 감싸 주는 함수 util에 추가

## 비고
- Card 컴포넌트의 summary도 util의 sentenceIntoParagraph 함수를 이용하여 수정헤야 합니다.
